### PR TITLE
[FEATURE] Add option to force password change instead of the reminder

### DIFF
--- a/Classes/Hook/BackendHook.php
+++ b/Classes/Hook/BackendHook.php
@@ -2,6 +2,7 @@
 namespace SpoonerWeb\BeSecurePw\Hook;
 
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+use SpoonerWeb\BeSecurePw\Utilities\PasswordExpirationUtility;
 /***************************************************************
  *  Copyright notice
  *
@@ -106,7 +107,16 @@ class BackendHook {
 	 */
 	public function processDatamap_preProcessFieldArray(&$incomingFieldArray, $table, $id, &$parentObj) {
 		if ($table == 'be_users' && $incomingFieldArray['password'] != '') {
-			$incomingFieldArray['tx_besecurepw_lastpwchange'] = time() + date('Z');
+				// only do that, if the record was edited from the user himself
+			if ($id == $GLOBALS['BE_USER']->user['uid'] && !$GLOBALS['BE_USER']->user['ses_backuserid']) {
+				$incomingFieldArray['tx_besecurepw_lastpwchange'] = time() + date('Z');
+				$incomingFieldArray['tx_besecurepw_forcepwchange'] = 0;
+			}
+
+			// trigger reload of the backend, if it was previously locked down
+			if(PasswordExpirationUtility::isBeUserPasswordExpired()) {
+				$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['be_secure_pw']['insertModuleRefreshJS'] = TRUE;
+			}
 		}
 	}
 }

--- a/Classes/Hook/RestrictModulesHook.php
+++ b/Classes/Hook/RestrictModulesHook.php
@@ -1,0 +1,86 @@
+<?php
+namespace SpoonerWeb\BeSecurePw\Hook;
+
+use SpoonerWeb\BeSecurePw\Utilities\PasswordExpirationUtility;
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2012 Andreas Kießling <andreas.kiessling@web.de>
+ *  (c) 2014 Christian Plattner <Christian.Plattner@world-direct.at>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *  A copy is found in the textfile GPL.txt and important notices to the license
+ *  from the author is found in LICENSE.txt distributed with these scripts.
+ *
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+class RestrictModulesHook implements \TYPO3\CMS\Core\SingletonInterface {
+	/**
+	 * Insert JavaScript code to refresh the module menu, if the password was updated and
+	 * the "force" option was set. The menu then only shows a limited set of available backend modules.
+	 *
+	 * @param array $params
+	 * @param mixed $pObj Reference back to the calling object (called from two different hooks, but we do not need it anyway)
+	 * @return string
+	 */
+	public function addRefreshJavaScript(array $params, $pObj) {
+		if ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['be_secure_pw']['insertModuleRefreshJS']) {
+			$pageRenderer = $GLOBALS['TBE_TEMPLATE']->getPageRenderer();
+			$label = $GLOBALS['LANG']->sL('LLL:EXT:be_secure_pw/Resources/Private/Language/locallang.xml:beSecurePw.backendNeedsToReload');
+			$pageRenderer->addExtOnReadyCode(
+				'alert("' . $label . '");
+					top.location.reload();
+					'
+			);
+		}
+	}
+
+	/**
+	 * If the password is expired, only load the necessary modules to change the password
+	 *
+	 * @param array $params
+	 * @param mixed $pObj
+	 */
+	public function postUserLookUp(array $params, $pObj) {
+		if (PasswordExpirationUtility::isBeUserPasswordExpired()) {
+			// remove admin rights, because otherwise we can't restrict access to the modules
+			$GLOBALS['BE_USER']->user['admin'] = 0;
+			// this grants the user access to the modules
+			$GLOBALS['BE_USER']->user['userMods'] = 'user,user_setup';
+			// remove all groups from the user, so he can not get access to any other modules than the ones we granted him
+			$GLOBALS['BE_USER']->user['usergroup'] = '';
+			// allow access to live and workspace, if the user is currently in a workspace, but the access is removed due to missing usergroup
+			$GLOBALS['BE_USER']->user['workspace_perms'] = 3;
+
+			// Disable all columns except password
+			$GLOBALS['TYPO3_USER_SETTINGS']['columns'] = array(
+				'password' => $GLOBALS['TYPO3_USER_SETTINGS']['columns']['password'],
+				'password2' => $GLOBALS['TYPO3_USER_SETTINGS']['columns']['password2'],
+			);
+
+			// Override showitem to remove tabs and all fields except password
+			$GLOBALS['TYPO3_USER_SETTINGS']['showitem'] = '--div--;LLL:EXT:be_secure_pw/Resources/Private/Language/ux_locallang_csh_mod.xml:option_newPassword.description,password,password2';
+		}
+	}
+
+}
+
+if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS['BE']['XCLASS']['ext/be_secure_pw/hook/class.tx_besecurepwrestrictModules_hook.phpodulesHook.php']) {
+	include_once($TYPO3_CONF_VARS['BE']['XCLASS']['ext/be_secure_pw/hook/class.tx_besecurepwrestrictModules_hook.phpodulesHook.php']);
+}
+?>

--- a/Classes/Hook/UserSetupHook.php
+++ b/Classes/Hook/UserSetupHook.php
@@ -3,6 +3,7 @@ namespace SpoonerWeb\BeSecurePw\Hook;
 
 use TYPO3\CMS\Core\Utility;
 use TYPO3\CMS\Core\Messaging\FlashMessage;
+use SpoonerWeb\BeSecurePw\Utilities\PasswordExpirationUtility;
 /***************************************************************
  *  Copyright notice
  *
@@ -71,6 +72,15 @@ class UserSetupHook {
 					}
 				}
 
+				$passwordExpiredNotice = NULL;
+				if ($extConf['forcePasswordChange'] && PasswordExpirationUtility::isBeUserPasswordExpired()) {
+					$passwordExpiredNotice = Utility\GeneralUtility::makeInstance('\\TYPO3\\CMS\\Core\\Messaging\\FlashMessage',
+						$GLOBALS['LANG']->getLL('beSecurePw.passwordExpiredBody'),
+						$GLOBALS['LANG']->getLL('beSecurePw.passwordExpiredHeader'),
+						FlashMessage::ERROR
+					);
+				}
+
 				// flash message with instructions for the user
 				$flashMessage = Utility\GeneralUtility::makeInstance(
 					'\\TYPO3\\CMS\\Core\\Messaging\\FlashMessage',
@@ -84,7 +94,7 @@ class UserSetupHook {
 					FlashMessage::INFO,
 					TRUE
 				);
-				$params['markers']['FLASHMESSAGES'] = '<div id="typo3-messages">' . $flashMessage->render() . '</div>';
+				$params['markers']['FLASHMESSAGES'] = '<div id="typo3-messages">' . ($passwordExpiredNotice ? $passwordExpiredNotice->render() : '') . $flashMessage->render() . '</div>';
 
 				// put flash message in front of content
 				if (strpos($params['moduleBody'], '###FLASHMESSAGES###') === FALSE) {

--- a/Classes/Utilities/PasswordExpirationUtility.php
+++ b/Classes/Utilities/PasswordExpirationUtility.php
@@ -1,0 +1,81 @@
+<?php
+namespace SpoonerWeb\BeSecurePw\Utilities;
+
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Backend\Utility\BackendUtility;
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2010 Thomas Loeffler <loeffler@spooner-web.de>
+ *  (c) 2012 Andreas Kießling <andreas.kiessling@web.de>
+ *  (c) 2014 Christian Plattner <christian.plattner@world-direct.at>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *  A copy is found in the textfile GPL.txt and important notices to the license
+ *  from the author is found in LICENSE.txt distributed with these scripts.
+ *
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+class PasswordExpirationUtility {
+	/**
+	 * Check the backend user record, if the password nees updating
+	 * Either because it is expired, or the checkbox to change on next login was set
+	 *
+	 * @static
+	 * @return bool FALSE if the password is still valid
+	 */
+	public function isBeUserPasswordExpired() {
+			// If ses_backuserid is set, an admin switched to that user. He should not be forced to change the password
+		if ($GLOBALS['BE_USER']->user['ses_backuserid']) {
+			return FALSE;
+		}
+
+			// exit, if cli user is found
+		if (GeneralUtility::isFirstPartOfStr($GLOBALS['BE_USER']->user['username'], '_cli')) {
+			return FALSE;
+		}
+
+		// checkbox in user record is set
+		if ($GLOBALS['BE_USER']->user['tx_besecurepw_forcepwchange']) {
+			return TRUE;
+		}
+
+		// if the user just updated his password, $GLOBALS['BE_USER'] record may still hold the old data
+		$beUser = BackendUtility::getRecord('be_users', $GLOBALS['BE_USER']->user['uid']);
+
+			// password is too old
+		$lastPwChange = $beUser['tx_besecurepw_lastpwchange'];
+		$lastLogin = $beUser['lastlogin'];
+
+			// get configuration of a secure password
+		$extConf = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['be_secure_pw']);
+
+		$validUntilConfiguration = trim($extConf['validUntil']);
+
+		$validUntil = 0;
+		if ($validUntilConfiguration != '') {
+			$validUntil = strtotime('- '.$validUntilConfiguration);
+		}
+
+		return (($validUntilConfiguration != '' && ($lastPwChange == 0 || $lastPwChange < $validUntil)) || $lastLogin == 0);
+	}
+}
+
+if (defined('TYPO3_MODE') && $TYPO3_CONF_VARS['BE']['XCLASS']['ext/be_secure_pw/lib/class.tx_besecurepw_checkBeUserRecord.php']) {
+	include_once($TYPO3_CONF_VARS['BE']['XCLASS']['ext/be_secure_pw/lib/class.tx_besecurepw_checkBeUserRecord.php']);
+}

--- a/Resources/Private/Language/locallang.xml
+++ b/Resources/Private/Language/locallang.xml
@@ -12,6 +12,11 @@
 - Active checks in password: &lt;b&gt;%s&lt;/b&gt;&lt;br /&gt;
 - Amount of checks which have to be successful: &lt;b&gt;%s&lt;/b&gt;&lt;br /&gt;
 			</label>
+			<label index="beSecurePw.passwordExpiredHeader">Your password is expired</label>
+			<label index="beSecurePw.passwordExpiredBody">Please enter a new password according to the requirements below.&lt;br /&gt;
+			After changing your password, the backend will be reloaded to grant access to other modules.
+			</label>
+			<label index="beSecurePw.backendNeedsToReload">The backend needs to be reloaded to restore access to other modules</label>
 			<label index="lowercaseChar">lowercase chars</label>
 			<label index="capitalChar">capital chars</label>
 			<label index="digit">digits</label>
@@ -30,6 +35,11 @@
 - Aktive Prüfungen für das Passwort: &lt;b&gt;%s&lt;/b&gt;&lt;br /&gt;
 - Anzahl der Prüfungen, die erfolgreich sein müssen: &lt;b&gt;%s&lt;/b&gt;&lt;br /&gt;
 			</label>
+			<label index="beSecurePw.passwordExpiredHeader">Ihr Passwort ist abgelaufen</label>
+			<label index="beSecurePw.passwordExpiredBody">Bitte geben Sie ein neues Passwort gemäß den untenstehenden Vorgaben ein.&lt;br /&gt;
+				Nach erfolgreicher Änderung ihres Passwortes, wird das Backend neu geladen.
+			</label>
+			<label index="beSecurePw.backendNeedsToReload">Das Backend muss neu geladen werden, um den Zugriff auf andere Module wieder herzustellen</label>
 			<label index="lowercaseChar">Kleinbuchstaben</label>
 			<label index="capitalChar">Großbuchstaben</label>
 			<label index="digit">Zahlen</label>

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -1,6 +1,12 @@
 	# cat=basic/enable/60; type=string; label= Period to remind the user (after login) for setting a new password. Please use english (e.g. "14 days")
 validUntil = 14 days
 
+	# cat=basic/enable/60; type=boolean; label= Force changing the password: This disables all modules except user_setup to force a change of the password when the validUntil period is over or the checkbox in the be_user record  is set
+forcePasswordChange = 0
+
+	# cat=basic/enable/60; type=boolean; label= Change password on first login: When a new user is created, force the password change on first login.
+changePasswordOnFirstLogin = 0
+
 	# cat=basic/enable/60; type=int [5-20]; label= Length of the password: Here you can set the minimal length of the BE user password. If nothing is set, default is 8.
 passwordLength = 8
 

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -12,7 +12,15 @@ $TYPO3_CONF_VARS['SC_OPTIONS']['typo3/template.php']['preStartPageHook'][] = 'Sp
 $TYPO3_CONF_VARS['SC_OPTIONS']['typo3/template.php']['moduleBodyPostProcess'][] = 'SpoonerWeb\\BeSecurePw\\Hook\\UserSetupHook->moduleBodyPostProcess';
 
 // password reminder
-$TYPO3_CONF_VARS['SC_OPTIONS']['typo3/backend.php']['constructPostProcess'][] = 'SpoonerWeb\\BeSecurePw\\Hook\\BackendHook->constructPostProcess';
+$extConf = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf'][$_EXTKEY]);
+// execution of is hook only needed in backend, but it is in the abstract class and could also be executed from frontend otherwise
+// if the backend is set to adminOnly, we can not enforce the change, because the hook removes the admin flag
+if ($extConf['forcePasswordChange'] && TYPO3_MODE === 'BE' && intval($TYPO3_CONF_VARS['BE']['adminOnly']) === 0) {
+	$TYPO3_CONF_VARS['SC_OPTIONS']['ext/setup/mod/index.php']['setupScriptHook'][] = 'SpoonerWeb\\BeSecurePw\\Hook\\RestrictModulesHook->addRefreshJavaScript';
+	$TYPO3_CONF_VARS['SC_OPTIONS']['t3lib/class.t3lib_userauth.php']['postUserLookUp'][] = 'SpoonerWeb\\BeSecurePw\\Hook\\RestrictModulesHook->postUserLookUp';
+} else {
+	$TYPO3_CONF_VARS['SC_OPTIONS']['typo3/backend.php']['constructPostProcess'][] = 'SpoonerWeb\\BeSecurePw\\Hook\\BackendHook->constructPostProcess';
+}
 $TYPO3_CONF_VARS['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processDatamapClass']['be_secure_pw'] = 'SpoonerWeb\\BeSecurePw\\Hook\\BackendHook';
 
 ?>


### PR DESCRIPTION
This feature exists for TYPO3 <6.0 (from Andreas Kießling)
Feature optional, disabled by default (ext_conf_templates.txt)
User is forced to visit a limited user-setup module to change their
password.

Resolves: #54755
Releases: master,6.2
Change-Id: I7713f18056d95b4affeb4c895e85fb5008abfa3f

**This commit is ready for pushing to review.typo3.org**
Unfortunately I have no Push permission there. Is it possible to get it?
